### PR TITLE
Add Login UI & AuthContextProvider with dummy data

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import MainLayout from "@/components/layout/MainLayout";
 import MenuContextProvider, { MenuContext } from "@/context/MenuContext";
+import { AuthProvider } from "@/context/AuthContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,11 +28,13 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        <MenuContextProvider>
-          <MainLayout>
-            {children}
-          </MainLayout>
-        </MenuContextProvider>
+        <AuthProvider>
+          <MenuContextProvider>
+            <MainLayout>
+              {children}
+            </MainLayout>
+          </MenuContextProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import React, { useState } from "react";
+import { useAuth } from "@/context/AuthContext"; 
+
+export default function Login() {
+    const { login } = useAuth();
+    const [username, setUsername] = useState("");
+    const [password, setPassword] = useState("");
+    const [error, setError] = useState<string | null>(null);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError(null);
+
+        const success = await login(username, password);
+        if (!success) {
+            setError("Invalid username or password");
+        }
+    };
+
+    return (
+        <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
+        <h1 className="text-3xl font-bold mb-4">Login</h1>
+        <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow-md w-96">
+            <div className="mb-4">
+                <label htmlFor="username" className="block text-sm font-medium text-gray-700 mb-2">Username</label>
+                <input 
+                    type="text" 
+                    id="username" 
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                    className="border border-gray-300 rounded p-2 w-full" />
+            </div>
+            <div className="mb-4">
+                <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">Password</label>
+                <input 
+                    type="password" 
+                    id="password" 
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="border border-gray-300 rounded p-2 w-full" />
+            </div>
+            {error && <p className="text-red-500 text-sm mb-4">{error}</p>}
+            <button type="submit" className="bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600">Login</button>
+        </form>
+        </div>
+    );
+}

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+import { useRouter } from "next/navigation";
+
+type User = {
+    username: string;
+};
+
+type AuthContextType = {
+    user: User | null;
+    login: (username: string, password: string) => Promise<boolean>;
+    logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+    const [user, setUser] = useState<User | null>(null);
+    const router = useRouter();
+
+    const login = async (username: string, password: string): Promise<boolean> => {
+        // 🧪 dummy user（Fixed later to use API）
+        const dummyUser = {
+            username: "testuser",
+            password: "password123",
+        };
+
+        if (username === dummyUser.username && password === dummyUser.password) {
+            setUser({ username });
+            router.push("/chat");
+            return true;
+        }
+
+        return false;
+    };
+
+    const logout = () => {
+        setUser(null);
+        router.push("/login");
+    };
+
+    return (
+        <AuthContext.Provider value={{ user, login, logout }}>
+            {children}
+        </AuthContext.Provider>
+    );
+};
+
+export const useAuth = (): AuthContextType => {
+    const context = useContext(AuthContext);
+    if (!context) throw new Error("useAuth must be used within an AuthProvider");
+    return context;
+};


### PR DESCRIPTION
- Add Login form
- Add AuthContextProvider with Dummy user data
- Redirect to `/chat` page if success
- Display error if failed to login
<img width="455" alt="Login_form" src="https://github.com/user-attachments/assets/01262348-0a60-4f6f-85b2-8f0d6c788e8e" />
