### PR TITLE
flow enhance with chat api

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,13 +1,9 @@
+import { ApiResponse } from '../models/commons';
+
 export interface SignupPayload {
     name: string;
     email: string;
     password: string;
-}
-  
-export interface ApiResponse<T = unknown> {
-    status: number;
-    message: string | null;
-    data: T | null;
 }
   
 export async function signupUser(payload: SignupPayload): Promise<ApiResponse> {

--- a/src/lib/openai_api.ts
+++ b/src/lib/openai_api.ts
@@ -1,0 +1,24 @@
+import { ApiResponse } from '../models/commons';
+import { chatPayload } from '../models/commons';
+
+  
+export async function chatWithText(payload: chatPayload): Promise<ApiResponse<string>> {
+    const token = localStorage.getItem("access_token");
+    const tokenType = localStorage.getItem("token_type") || "Bearer";
+
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/chat`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `${tokenType} ${token}`,
+        },
+        body: JSON.stringify(payload),
+    });
+  
+    const data = await res.json();
+    return {
+        status: data.status,
+        message: data.message,
+        data: data.data,
+    };
+}

--- a/src/models/commons.ts
+++ b/src/models/commons.ts
@@ -1,6 +1,22 @@
+export interface ApiResponse<T = unknown> {
+    status: number;
+    message: string | null;
+    data: T | null;
+}
 
 export interface Conversation {
     id: number;
     title: string;
     userId: number;
+}
+
+export interface Message {
+    role: string;
+    content: string;
+}
+
+export interface chatPayload {
+    message: string;
+    history: Message[] | [];
+    language: string;
 }


### PR DESCRIPTION
- Remove dummy data from `MainChat` 
- Define `Message` interface in models/common.ts
- Fixed to use `content` instead of `message` in `MainChat` 
- Fixed layout to use `flex`  `justify-end` and `justify-start` instead of `text-right` or `text-left` 
- Add `/chat` API call to get response (`assistant`) from OpenAI model