### PR TITLE
Feature chat sidebar UI enhance

### DIFF
--- a/src/app/chat2/page.tsx
+++ b/src/app/chat2/page.tsx
@@ -8,6 +8,7 @@ import MainChat from "@/components/MainChat";
 import { Conversation, Message } from "@/models/commons";
 import { getUserConversations, getMessages } from "@/lib/conversation_api";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
+import { BiSidebar } from "react-icons/bi";
 
 export interface ChatPageProps {
   conversationId: string | null;
@@ -18,6 +19,7 @@ const ChatPage2: React.FC<ChatPageProps> = ({conversationId}) => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const router = useRouter();
 
   const fetchConversations = async () => {
@@ -53,6 +55,16 @@ const ChatPage2: React.FC<ChatPageProps> = ({conversationId}) => {
     }
   }, [conversationId]);
 
+  // useEffect(() => {
+  //   const updateLayout = () => {
+  //     setIsCompactLayout(window.innerWidth < 1024); // Tailwind's `lg`
+  //   };
+
+  //   updateLayout(); // Initial check
+  //   window.addEventListener("resize", updateLayout);
+  //   return () => window.removeEventListener("resize", updateLayout);
+  // }, []);
+
   const handleNewConversation = () => {
     router.push("/chat2")
   };
@@ -64,13 +76,24 @@ const ChatPage2: React.FC<ChatPageProps> = ({conversationId}) => {
   return (
     <ProtectedRoute>
       <div className="flex h-screen container mx-auto">
-        {/* Sidebar */}
-        <Sidebar
-          conversations={conversations}
-          onNewConversation={handleNewConversation}
-          onSelectConversation={handleSelectConversation}
-          selectedIndex={selectedIndex}
-        />
+        {/*Sidebar Toggle Button*/}
+        <button
+          className="fixed top-2 left-4 z-50 p-2 bg-blue-600 text-white rounded-full"
+          onClick={() => setIsSidebarOpen(!isSidebarOpen)}  
+        > 
+          <BiSidebar size={24} />
+        </button>
+        {isSidebarOpen && (
+          <div className={`fixed left-0 z-50 lg:relative lg:z-0 lg:block`}>
+            <Sidebar
+              conversations={conversations}
+              onNewConversation={handleNewConversation}
+              onSelectConversation={handleSelectConversation}
+              selectedIndex={selectedIndex}
+            />
+          </div>
+        )}
+        
 
         {/* Chat Area */}
         <MainChat

--- a/src/app/chat2/page.tsx
+++ b/src/app/chat2/page.tsx
@@ -18,7 +18,6 @@ const ChatPage2: React.FC<ChatPageProps> = ({conversationId}) => {
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(false);
-  const [selectedIndex, setSelectedIndex] = useState(0);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const router = useRouter();
 
@@ -55,23 +54,11 @@ const ChatPage2: React.FC<ChatPageProps> = ({conversationId}) => {
     }
   }, [conversationId]);
 
-  // useEffect(() => {
-  //   const updateLayout = () => {
-  //     setIsCompactLayout(window.innerWidth < 1024); // Tailwind's `lg`
-  //   };
-
-  //   updateLayout(); // Initial check
-  //   window.addEventListener("resize", updateLayout);
-  //   return () => window.removeEventListener("resize", updateLayout);
-  // }, []);
 
   const handleNewConversation = () => {
     router.push("/chat2")
   };
 
-  const handleSelectConversation = (index: number) => {
-    setSelectedIndex(index);
-  };
 
   return (
     <ProtectedRoute>
@@ -88,8 +75,6 @@ const ChatPage2: React.FC<ChatPageProps> = ({conversationId}) => {
             <Sidebar
               conversations={conversations}
               onNewConversation={handleNewConversation}
-              onSelectConversation={handleSelectConversation}
-              selectedIndex={selectedIndex}
             />
           </div>
         )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -44,3 +44,23 @@ a {
     color-scheme: dark;
   }
 }
+
+
+/* Custom scrollbar for sidebar */
+.custom-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: #4B5563 #1F2937; /* thumb / track for Firefox */
+}
+
+.custom-scrollbar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: #1F2937; /* Tailwind gray-800 */
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background-color: #4B5563; /* Tailwind gray-700 */
+  border-radius: 4px;
+}

--- a/src/components/MainChat.tsx
+++ b/src/components/MainChat.tsx
@@ -142,35 +142,35 @@ const MainChat: React.FC<MainChatProps> = ({
     }
 
     return (
-        <main className="flex-1 flex flex-col bg-white">
-            <div className="p-6 overflow-y-auto flex-1">
-            <div className="space-y-4 mx-8">
-                {messages.map((msg, index) => (
-                    <div key={index} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
-                        <p className={`bg-${msg.role === 'user' ? 'blue-100' : 'gray-100'} inline-block p-3 rounded shadow max-w-md`}>
-                            {msg.role === "assistant" && msg.translatedContent && showTranslations[index]
-                                ? msg.translatedContent
-                                : msg.content}
-                        </p>
-                        {msg.role === 'assistant' && msg.audioUrl && (
-                            <AudioPlayer audioUrl={msg.audioUrl} />
-                        )}
-                        {msg.role === "assistant" && msg.translatedContent && (
-                            <BsTranslate
-                                className="text-gray-500 cursor-pointer mx-2 mt-1"
-                                size={24}
-                                onClick={() => toggleTranslation(index)}
-                                title="Toggle translation"
-                            />
-                        )}
-                    </div>
-                ))}
-                {isLoading && ( 
-                    <div className="flex justify-center items-center mt-4">
-                        <img src="/Spinner-5.gif" alt="Loading..." className="w-12 h-12 animate-spin" />
-                    </div>
-                )}
-            </div>
+        <main className="flex-1 flex flex-col bg-gray-300">
+            <div className="overflow-y-auto p-6">
+                <div className="space-y-4 mx-8">
+                    {messages.map((msg, index) => (
+                        <div key={index} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+                            <p className={`bg-${msg.role === 'user' ? 'blue-100' : 'gray-100'} inline-block p-3 rounded shadow max-w-md`}>
+                                {msg.role === "assistant" && msg.translatedContent && showTranslations[index]
+                                    ? msg.translatedContent
+                                    : msg.content}
+                            </p>
+                            {msg.role === 'assistant' && msg.audioUrl && (
+                                <AudioPlayer audioUrl={msg.audioUrl} />
+                            )}
+                            {msg.role === "assistant" && msg.translatedContent && (
+                                <BsTranslate
+                                    className="text-gray-500 cursor-pointer mx-2 mt-1"
+                                    size={24}
+                                    onClick={() => toggleTranslation(index)}
+                                    title="Toggle translation"
+                                />
+                            )}
+                        </div>
+                    ))}
+                    {isLoading && ( 
+                        <div className="flex justify-center items-center mt-4">
+                            <img src="/Spinner-5.gif" alt="Loading..." className="w-12 h-12 animate-spin" />
+                        </div>
+                    )}
+                </div>
             </div>
 
             <div className="p-4 border-t flex items-center space-x-2 m-8">

--- a/src/components/layout/MainHeader.tsx
+++ b/src/components/layout/MainHeader.tsx
@@ -8,6 +8,10 @@ const MainHeader: React.FC = () => {
     const { toggleMenu } = React.useContext(MenuContext);
     return (
         <header className="bg-white flex justify-between items-center p-4 shadow-md">
+            <nav className="hidden md:flex space-x-4" />
+            <div className="flex items-center">
+                <h1 className="text-xl font-bold">AI Voice Chat</h1>
+            </div>
             <div onClick={toggleMenu}><FaBars/></div>
         </header>
     );

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -20,11 +20,11 @@ const MainLayout: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
     const { isMenuOpen, toggleMenu } = useContext(MenuContext);
     const { isAuthenticated, logout } = useAuth();
     return (
-        <div className="min-h-screen bg-gray-100 w-full">
+        <div className="flex flex-col h-screen bg-gray-100 w-full">
             <MainHeader />
             <div className="relative flex-1">
                 {isMenuOpen && (
-                    <aside className="fixed top-16 left-0 z-50 bg-white w-60 h-full shadow-lg p-4 rounded-r-lg transition duration-300 ease-in-out">
+                    <aside className="fixed top-16 right-0 z-50 bg-white w-60 shadow-lg p-4 rounded-r-lg transition duration-300 ease-in-out">
                         <ul>
                             <li className="flex justify-start items-center p-2 hover:bg-blue-200 rounded-lg transition duration-200 ease-in-out">
                                 <AiOutlineHome className="mr-2" />

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -22,14 +22,14 @@ const Sidebar: React.FC<SidebarProps> = ({
   }
 
   return (
-    <aside className="w-64 bg-gray-900 text-white p-4">
+    <aside className="w-64 h-screen flex flex-col bg-gray-900 text-white p-4">
       <button
         onClick={onNewConversation}
         className="mb-4 bg-blue-600 w-full py-2 rounded"
       >
         + New Chat
       </button>
-      <ul>
+      <ul className="flex-1 overflow-y-auto pr-1 custom-scrollbar">
         {conversations.map((conversation, index) => (
           <li
             key={index}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -6,15 +6,11 @@ import { Conversation } from '../models/commons'
 interface SidebarProps {
   conversations: Conversation[];
   onNewConversation: () => void;
-  onSelectConversation: (index: number) => void;
-  selectedIndex: number;
 }
 
 const Sidebar: React.FC<SidebarProps> = ({
   conversations,
-  onNewConversation,
-  onSelectConversation,
-  selectedIndex,
+  onNewConversation
 }) => {
   const router = useRouter();
   const handleSelectedConversation = (id: string) => {
@@ -33,9 +29,7 @@ const Sidebar: React.FC<SidebarProps> = ({
         {conversations.map((conversation, index) => (
           <li
             key={index}
-            className={`mb-2 cursor-pointer p-2 rounded hover:bg-gray-800 ${
-              selectedIndex === index ? "bg-gray-800" : ""
-            }`}
+            className={`mb-2 cursor-pointer p-2 rounded hover:bg-gray-800`}
             onClick={() => handleSelectedConversation(conversation.id.toString())}
           >
             {conversation.title}


### PR DESCRIPTION
- Add toggle button to show & hide Sidebar at chat
#### when width is narrow, Show side bar overlaps with chat content.
<img width="377" alt="Sidebar-toggle-button" src="https://github.com/user-attachments/assets/a3a4273f-53c1-484a-9c25-3d9046065baf" />

<img width="377" alt="Sidebar-show-menu" src="https://github.com/user-attachments/assets/434de8bd-fe54-4026-bfab-dbf0eb0e0764" />

#### when width is large enough (more than 1024px)
<img width="747" alt="Sidebar-show-lg-large" src="https://github.com/user-attachments/assets/9b7f0c8f-bfcf-4f9d-a446-0e81486b6744" />

- Problem: browser shows scrollbar automatically because using `h-screen` at parent and child component.